### PR TITLE
Remove unnecessary `dead_code` flags

### DIFF
--- a/crates/bonsai-runner/src/lib.rs
+++ b/crates/bonsai-runner/src/lib.rs
@@ -16,7 +16,6 @@ use boundless_market::{
 use risc0_zkvm::{compute_image_id, default_executor, sha::Digestible, Receipt};
 use tracing::info;
 
-#[allow(dead_code)]
 pub fn as_input_data<T: BorshSerialize>(data: &T) -> Result<Vec<u8>> {
     let data = borsh::to_vec(&data)?;
     let size = risc0_zkvm::serde::to_vec(&data.len())?;
@@ -173,7 +172,6 @@ pub async fn run_boundless(elf: &[u8], input_data: Vec<u8>) -> Result<Receipt> {
     Ok(receipt)
 }
 
-#[allow(dead_code)]
 pub async fn run_bonsai(elf: &[u8], input_data: Vec<u8>) -> Result<Receipt> {
     let client = Client::from_env(risc0_zkvm::VERSION)?;
 

--- a/crates/client-sdk/src/rest_client.rs
+++ b/crates/client-sdk/src/rest_client.rs
@@ -212,7 +212,6 @@ impl NodeApiHttpClient {
     }
 
     /// Create a new client with a retry configuration (retrying `n` times, waiting `duration` before each retry)
-    #[allow(dead_code)]
     pub fn with_retry(&self, n: usize, duration: Duration) -> Self {
         let mut cloned = self.clone();
         cloned.retry = Some((n, duration));
@@ -220,7 +219,6 @@ impl NodeApiHttpClient {
     }
 
     /// Create a client with the retry configuration (n=3, duration=1000ms)
-    #[allow(dead_code)]
     pub fn retry_15times_1000ms(&self) -> Self {
         self.with_retry(8, Duration::from_millis(4000))
     }
@@ -349,7 +347,6 @@ impl DerefMut for NodeApiHttpClient {
     }
 }
 
-#[allow(dead_code)]
 pub mod test {
     use sdk::Hashed;
 


### PR DESCRIPTION
These flags were perhaps useful in the past