### PR TITLE
Fix Typos in Documentation and Source Code Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ cargo run -- --pg
 ```
 
 It will start a postgres server for you, and will close it (with all its data) whenever you stop the node.
-This is usefull during development.
+This is useful during development.
 
-If you want data persistance, you can run the PostgreSQL server:
+If you want data persistence, you can run the PostgreSQL server:
 
 ```bash
 # Start PostgreSQL with default configuration:

--- a/crates/hyle-modules/src/modules/mod.rs
+++ b/crates/hyle-modules/src/modules/mod.rs
@@ -78,7 +78,7 @@ where
     fn persist(&mut self) -> impl futures::Future<Output = Result<()>> + Send {
         async {
             info!(
-                "Persistance is not implemented for module {}",
+                "Persistence is not implemented for module {}",
                 type_name::<Self>()
             );
             Ok(())
@@ -714,7 +714,7 @@ mod tests {
         );
     }
 
-    // When modules are strated in the following order A, B, C, they should be closed in the reverse order C, B, A
+    // When modules are started in the following order A, B, C, they should be closed in the reverse order C, B, A
     #[tokio::test]
     async fn test_start_stop_modules_in_order() {
         let shared_bus = SharedMessageBus::new(BusMetrics::global("id".to_string()));
@@ -812,12 +812,12 @@ mod tests {
 
         _ = handler.start_modules().await;
 
-        // Starting shutdown loop should shut all modules because one failed immediatly
+        // Starting shutdown loop should shut all modules because one failed immediately
 
         _ = handler.shutdown_loop().await;
 
         // u64 module fails first, emits two events, one because it is the first task to end,
-        // and the other because it finished to shutdown corretly
+        // and the other because it finished to shutdown correctly
         assert_eq!(
             shutdown_completed_receiver.recv().await.unwrap().module,
             std::any::type_name::<TestModule<u64>>().to_string()
@@ -861,7 +861,7 @@ mod tests {
 
         _ = handler.start_modules().await;
 
-        // Starting shutdown loop should shut all modules because one failed immediatly
+        // Starting shutdown loop should shut all modules because one failed immediately
 
         _ = handler.shutdown_loop().await;
 

--- a/src/mempool/own_lane.rs
+++ b/src/mempool/own_lane.rs
@@ -57,7 +57,7 @@ impl super::Mempool {
         let new_voting_power = self.staking.compute_voting_power(validators.as_slice());
         let f = self.staking.compute_f();
         // Only send the message if voting power exceeds f, 2 * f or is exactly 3 * f + 1
-        // This garentees that the message is sent only once per threshold
+        // This guarantees that the message is sent only once per threshold
         if old_voting_power < f && new_voting_power >= f
             || old_voting_power < 2 * f && new_voting_power >= 2 * f
             || new_voting_power > 3 * f
@@ -307,7 +307,7 @@ impl super::Mempool {
 
         // Brittle logic - some TXs might have been skipped over due to size limits.
         // This means their WaitingDissemination status will not be updated (as their TxId effectively changes).
-        // Listeners might need to update any TX with this DPHash as parent and _not_ withing txs_metadatas.
+        // Listeners might need to update any TX with this DPHash as parent and _not_ within txs_metadatas.
         self.bus
             .send(MempoolStatusEvent::DataProposalCreated {
                 parent_data_proposal_hash,


### PR DESCRIPTION


---

**Description:**  
This pull request corrects several spelling mistakes in documentation and code comments across the project.  
- Fixed words like `usefull`, `persistance`, `garnetees`, `corectly`, and others.
- Improved clarity and professionalism in user-facing documentation and internal comments.



---