### PR TITLE
docs: fix execute function type parameter documentation

### DIFF
--- a/crates/contract-sdk/src/guest.rs
+++ b/crates/contract-sdk/src/guest.rs
@@ -125,7 +125,7 @@ impl GuestEnv for SP1Env {
 ///
 /// # Type Parameters
 ///
-/// * `State` - The type of the state that must implement the `ZkProgram` and `BorshDeserialize` traits.
+/// * `Z` - The type of the contract that must implement the `ZkContract` and `BorshDeserialize` traits.
 ///
 /// # Returns
 ///


### PR DESCRIPTION
Correct the type parameter documentation in execute function:
- Use "Z" instead of "State" 
- Require "ZkContract" instead of "ZkProgram"