### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/github_stars.yml
+++ b/.github/workflows/github_stars.yml
@@ -14,14 +14,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ci_cache
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm install axios


### PR DESCRIPTION


This PR updates the GitHub Actions workflow dependencies to their latest stable versions:

- **actions/checkout**: `v3` → `v4`
- **actions/setup-node**: `v3` → `v4` 
- **Node.js**: `16` → `24`

