### PR TITLE
chore(crypto): remove unused SIG_SIZE constant

### DIFF
--- a/crates/hyle-crypto/src/lib.rs
+++ b/crates/hyle-crypto/src/lib.rs
@@ -54,7 +54,6 @@ struct Aggregates {
 }
 
 const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
-pub const SIG_SIZE: usize = 48;
 
 impl BlstCrypto {
     #[cfg(not(test))]


### PR DESCRIPTION
Remove unused and misleading SIG_SIZE constant from Blst crypto module. In blst min_pk, compressed signatures are 96 bytes (not 48). The constant was unused and could cause confusion. No functional changes.