### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           # - beta
           # - nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
 
       # For keyring dependencies
@@ -73,7 +73,7 @@ jobs:
           # - beta
           # - nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -106,7 +106,7 @@ jobs:
           # - beta
           # - nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
         with:
@@ -125,6 +125,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Machete
         uses: bnjbvr/cargo-machete@v0.7.1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # For keyring dependencies
       - run: sudo apt install libdbus-1-dev pkg-config
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/crate-compilation.yml
+++ b/.github/workflows/crate-compilation.yml
@@ -24,7 +24,7 @@ jobs:
     needs: list-crates
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
 
@@ -48,7 +48,7 @@ jobs:
       crates: ${{ steps.crate-list.outputs.crates }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v5 
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update_contracts_pr.yml
+++ b/.github/workflows/update_contracts_pr.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Récupère tout l'historique pour éviter les problèmes
       - name: Install rzup


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0