### PR TITLE
fix: translate French comments to English in mask_postgres_uri function

### DIFF
--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -98,18 +98,18 @@ impl Drop for RunPg {
 }
 
 fn mask_postgres_uri(uri: &str) -> String {
-    // On cherche le prefix postgres://user:pass@...
+    // Look for the postgres://user:pass@... prefix
     if let Some(start) = uri.find("://") {
         if let Some(at) = uri[start + 3..].find('@') {
             let creds_part = &uri[start + 3..start + 3 + at];
             if let Some(colon) = creds_part.find(':') {
                 let user = &creds_part[..colon];
-                let rest = &uri[start + 3 + at..]; // tout après @
+                let rest = &uri[start + 3 + at..]; // everything after @
                 return format!("postgres://{}:{}{}", user, "*****", rest);
             }
         }
     }
-    uri.to_string() // fallback : renvoyer tel quel si pas reconnu
+    uri.to_string() // fallback: return as-is if not recognized
 }
 
 pub fn welcome_message(conf: &conf::Conf) {


### PR DESCRIPTION
Replace French comments with English equivalents in the mask_postgres_uri function to maintain consistency with the project's code style.

- "On cherche le prefix postgres://user:pass@..." → "Look for the postgres://user:pass@... prefix"
- "tout après @" → "everything after @"
- "fallback : renvoyer tel quel si pas reconnu" → "fallback: return as-is if not recognized"
