### PR TITLE
fix: Use correct test prover generic for Hydentity

### DIFF
--- a/crates/hyli-loadtest/src/lib.rs
+++ b/crates/hyli-loadtest/src/lib.rs
@@ -464,7 +464,7 @@ pub async fn long_running_test(node_url: String, use_test_verifier: bool) -> Res
             tx_ctx = tx_ctx
                 .with_prover(
                     random_hydentity_contract.clone(),
-                    TxExecutorTestProver::<Hyllar>::new(),
+                    TxExecutorTestProver::<Hydentity>::new(),
                 )
                 .with_prover(
                     random_hyllar_contract.clone(),


### PR DESCRIPTION
Replace TxExecutorTestProver::<Hyllar> with TxExecutorTestProver::<Hydentity> for the Hydentity contract in long_running_test.
Ensures commitment metadata deserializes into the correct contract type during test verification.