### PR TITLE
perf: remove redundant clones in hashing and ProgramId conversions

### DIFF
--- a/crates/hyli-model/src/contract.rs
+++ b/crates/hyli-model/src/contract.rs
@@ -709,7 +709,7 @@ impl<S: Into<String>> From<S> for Verifier {
 }
 impl From<Vec<u8>> for ProgramId {
     fn from(v: Vec<u8>) -> Self {
-        ProgramId(v.clone())
+        ProgramId(v)
     }
 }
 impl From<&Vec<u8>> for ProgramId {
@@ -724,7 +724,7 @@ impl<const N: usize> From<&[u8; N]> for ProgramId {
 }
 impl From<&[u8]> for ProgramId {
     fn from(v: &[u8]) -> Self {
-        ProgramId(v.to_vec().clone())
+        ProgramId(v.to_vec())
     }
 }
 

--- a/crates/hyli-model/src/node/data_availability.rs
+++ b/crates/hyli-model/src/node/data_availability.rs
@@ -107,7 +107,7 @@ impl Hashed<BlobProofOutputHash> for BlobProofOutput {
         let mut hasher = Sha3_256::new();
         hasher.update(self.blob_tx_hash.0.as_bytes());
         hasher.update(self.original_proof_hash.0.as_bytes());
-        hasher.update(self.program_id.0.clone());
+        hasher.update(self.program_id.0.as_slice());
         hasher.update(contract::Hashed::hashed(&self.hyli_output).0);
         BlobProofOutputHash(hasher.finalize().to_vec())
     }
@@ -118,8 +118,8 @@ impl Hashed<HyliOutputHash> for HyliOutput {
     fn hashed(&self) -> HyliOutputHash {
         let mut hasher = Sha3_256::new();
         hasher.update(self.version.to_le_bytes());
-        hasher.update(self.initial_state.0.clone());
-        hasher.update(self.next_state.0.clone());
+        hasher.update(self.initial_state.0.as_slice());
+        hasher.update(self.next_state.0.as_slice());
         hasher.update(self.identity.0.as_bytes());
         hasher.update(self.index.0.to_le_bytes());
         for blob in &self.blobs {

--- a/crates/hyli-model/src/transaction.rs
+++ b/crates/hyli-model/src/transaction.rs
@@ -189,7 +189,7 @@ impl Hashed<TxHash> for ProofTransaction {
     fn hashed(&self) -> TxHash {
         let mut hasher = Sha3_256::new();
         hasher.update(self.contract_name.0.as_bytes());
-        hasher.update(self.program_id.0.clone());
+        hasher.update(self.program_id.0.as_slice());
         hasher.update(self.verifier.0.as_bytes());
         hasher.update(self.proof.hashed().0);
         let hash_bytes = hasher.finalize();

--- a/src/consensus/network.rs
+++ b/src/consensus/network.rs
@@ -197,10 +197,10 @@ pub enum ConsensusNetMessage {
 impl<T> Hashed<QuorumCertificateHash> for QuorumCertificate<T> {
     fn hashed(&self) -> QuorumCertificateHash {
         let mut hasher = Sha3_256::new();
-        hasher.update(self.signature.0.clone());
+        hasher.update(self.signature.0.as_slice());
         hasher.update(self.validators.len().to_le_bytes());
         for validator in self.validators.iter() {
-            hasher.update(validator.0.clone());
+            hasher.update(validator.0.as_slice());
         }
         QuorumCertificateHash(hasher.finalize().as_slice().to_owned())
     }


### PR DESCRIPTION
Removed redundant copies in ProgramId:
- From<Vec<u8>>: ProgramId(v.clone()) → ProgramId(v)
- From<&[u8]>: ProgramId(v.to_vec().clone()) → ProgramId(v.to_vec())
Replaced .clone() with slices in hashing:
- crates/hyli-model/src/node/data_availability.rs: program_id, initial_state, next_state
- crates/hyli-model/src/transaction.rs: ProofTransaction.program_id
- src/consensus/network.rs: QuorumCertificate.signature, validator
Motivation: remove unnecessary allocations/copying without changing semantics; hasher.update accepts AsRef<[u8]>.
Behavior remains unchanged, hashes are identical; changes are safe.
