### PR TITLE
single_node_consensus: propagate actual staking in commit event

### DIFF
--- a/src/single_node_consensus.rs
+++ b/src/single_node_consensus.rs
@@ -224,7 +224,7 @@ impl SingleNodeConsensus {
 
         self.bus.send(ConsensusEvent::CommitConsensusProposal(
             CommittedConsensusProposal {
-                staking: Staking::default(),
+                staking: self.store.staking.clone(),
                 consensus_proposal,
                 certificate: certificate.signature,
             },


### PR DESCRIPTION
- Replace Staking::default() with self.store.staking.clone() when emitting ConsensusEvent::CommitConsensusProposal
- Prevents mempool from resetting its staking state on commit
- Aligns single-node behavior with the main consensus path