### PR TITLE
Fix: Correct spelling errors across codebase

### DIFF
--- a/crates/contracts/README.md
+++ b/crates/contracts/README.md
@@ -8,7 +8,7 @@ This folder contains some "official" Hyli Risc0 smart contracts :
 - `risc0-recursion`: A contract with special rights to do recursion on multiple contracts
 - `staking`: A contract used to hold partg of the staking logic for the consensus.
 
-This architecture is subject to change while sdk will be developped.
+This architecture is subject to change while sdk will be developed.
 
 To regenerate the _.img and _.txt files, you should run
 

--- a/crates/hyli-modules/src/modules/mod.rs
+++ b/crates/hyli-modules/src/modules/mod.rs
@@ -80,7 +80,7 @@ where
     fn persist(&mut self) -> impl futures::Future<Output = Result<()>> + Send {
         async {
             info!(
-                "Persistance is not implemented for module {}",
+                "Persistence is not implemented for module {}",
                 type_name::<Self>()
             );
             Ok(())
@@ -725,7 +725,7 @@ mod tests {
         );
     }
 
-    // When modules are strated in the following order A, B, C, they should be closed in the reverse order C, B, A
+    // When modules are started in the following order A, B, C, they should be closed in the reverse order C, B, A
     #[tokio::test]
     async fn test_start_stop_modules_in_order() {
         let shared_bus = SharedMessageBus::new(BusMetrics::global("id".to_string()));
@@ -823,12 +823,12 @@ mod tests {
 
         _ = handler.start_modules().await;
 
-        // Starting shutdown loop should shut all modules because one failed immediatly
+        // Starting shutdown loop should shut all modules because one failed immediately
 
         _ = handler.shutdown_loop().await;
 
         // u64 module fails first, emits two events, one because it is the first task to end,
-        // and the other because it finished to shutdown corretly
+        // and the other because it finished to shutdown correctly
         assert_eq!(
             shutdown_completed_receiver.recv().await.unwrap().module,
             std::any::type_name::<TestModule<u64>>().to_string()
@@ -872,7 +872,7 @@ mod tests {
 
         _ = handler.start_modules().await;
 
-        // Starting shutdown loop should shut all modules because one failed immediatly
+        // Starting shutdown loop should shut all modules because one failed immediately
 
         _ = handler.shutdown_loop().await;
 

--- a/crates/hyli-modules/src/node_state.rs
+++ b/crates/hyli-modules/src/node_state.rs
@@ -606,7 +606,7 @@ impl<'any> NodeStateProcessing<'any> {
             bail!("BlobTx {} not found", &blob_tx_hash);
         };
 
-        // TODO: add diverse verifications ? (without the inital state checks!).
+        // TODO: add diverse verifications ? (without the initial state checks!).
         // TODO: success to false is valid outcome and can be settled.
 
         Self::verify_hyli_output(unsettled_tx, &blob_proof_data.hyli_output)?;
@@ -792,7 +792,7 @@ impl<'any> NodeStateProcessing<'any> {
         mut blob_proof_output_indices: Vec<usize>,
         callback: &mut (dyn NodeStateCallback + Send + Sync),
     ) -> SettlementResult {
-        // Recursion end-case: we succesfully settled all prior blobs, so success.
+        // Recursion end-case: we successfully settled all prior blobs, so success.
         let Some((blob, possible_proofs)) = blob_iter.next() else {
             // Sanity checks
             for (contract_name, (contract_status, _, _)) in contract_changes.iter() {

--- a/crates/hyli-modules/src/node_state/hyli_tld.rs
+++ b/crates/hyli-modules/src/node_state/hyli_tld.rs
@@ -131,7 +131,7 @@ fn handle_update_program_id_blob(
 ) -> Result<()> {
     // For now, Hyli is allowed to delete all contracts but itself
     if update.contract_name.0 == "hyli" {
-        bail!("Cannot udpate Hyli contract");
+        bail!("Cannot update Hyli contract");
     }
 
     let contract =
@@ -170,7 +170,7 @@ fn handle_update_timeout_window_blob(
 ) -> Result<()> {
     // For now, Hyli is allowed to delete all contracts but itself
     if update.contract_name.0 == "hyli" {
-        bail!("Cannot udpate Hyli contract");
+        bail!("Cannot update Hyli contract");
     }
 
     let contract =

--- a/crates/hyli-modules/src/node_state/test/node_state_tests.rs
+++ b/crates/hyli-modules/src/node_state/test/node_state_tests.rs
@@ -137,7 +137,7 @@ async fn assert_two_transactions_with_different_contracts_using_same_native_cont
     assert_eq!(block.failed_txs.len(), 0);
     assert_eq!(block.successful_txs.len(), 1);
 
-    // Check state transitionned correctly
+    // Check state transitioned correctly
     assert_eq!(state.contracts.get(&d1).unwrap().state.0, vec![4, 5, 6]);
 
     // Now settle the first one


### PR DESCRIPTION

- **README.md**: Fixed "developped" → "developed"
- **mod.rs**: Corrected "Persistance" → "Persistence" and "strated" → "started"
- **node_state.rs**: Fixed "immediatly" → "immediately", "inital" → "initial", "succesfully" → "successfully"
- **hyli_tld.rs**: Corrected "udpate" → "update" in error messages
- **node_state_tests.rs**: Fixed "transitionned" → "transitioned"

